### PR TITLE
Fixes NPE when target dir does not exist

### DIFF
--- a/src/main/java/com/microfocus/plugins/attribution/datamodel/services/impl/ReportsServiceImpl.java
+++ b/src/main/java/com/microfocus/plugins/attribution/datamodel/services/impl/ReportsServiceImpl.java
@@ -29,6 +29,12 @@ public class ReportsServiceImpl implements ReportsService {
     @Override
     public void createAttributionXmlFile(List<ProjectDependency> projectDependencies, File outputFile) {
         try {
+            // ensure parent dirs exist
+            final File parentFile = outputFile.getParentFile();
+            if (parentFile != null) {
+                parentFile.mkdirs();
+            }
+
             Serializer serializer = new Persister();
 
             AttributionReport attributionReport = new AttributionReport();

--- a/src/test/java/com/microfocus/plugins/attribution/datamodel/services/impl/ReportsServiceImplTest.java
+++ b/src/test/java/com/microfocus/plugins/attribution/datamodel/services/impl/ReportsServiceImplTest.java
@@ -1,0 +1,67 @@
+package com.microfocus.plugins.attribution.datamodel.services.impl;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.google.common.collect.Lists;
+import com.microfocus.plugins.attribution.datamodel.beans.ProjectDependency;
+
+public class ReportsServiceImplTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ReportsServiceImpl reportsServiceImpl;
+
+    @Before
+    public void setUp() {
+	reportsServiceImpl = new ReportsServiceImpl();
+    }
+
+    @Test
+    public void testEnsureParentDirectoryExists() {
+        // given a output file in a non-existing target directory
+        final File targetDir = new File(folder.getRoot(), "target");
+        final File outputFile = new File(targetDir, "attribution.xml");
+
+        // given a dummy project dependency
+        final ProjectDependency projectDependency = new ProjectDependency();
+        projectDependency.setGroupId("groupId");
+        projectDependency.setArtifactId("artifactId");
+        projectDependency.setVersion("version");
+        final List<ProjectDependency> projectDependencies = Lists.newArrayList(projectDependency);
+
+        // when writing the attributions file
+        reportsServiceImpl.createAttributionXmlFile(projectDependencies, outputFile);
+
+        // then the file could be written
+        assertTrue(outputFile.exists());
+    }
+
+    @Test
+    public void testEnsureParentDirExistsDoesNotFailOnMissingParentDir() {
+        // given a output file in a non-existing target directory
+        final File outputFile = new File("attribution.xml");
+        outputFile.deleteOnExit();
+
+        // given a dummy project dependency
+        final ProjectDependency projectDependency = new ProjectDependency();
+        projectDependency.setGroupId("groupId");
+        projectDependency.setArtifactId("artifactId");
+        projectDependency.setVersion("version");
+        final List<ProjectDependency> projectDependencies = Lists.newArrayList(projectDependency);
+
+        // when writing the attributions file
+        reportsServiceImpl.createAttributionXmlFile(projectDependencies, outputFile);
+
+        // then the file could be written
+        assertTrue(outputFile.exists());
+    }
+}


### PR DESCRIPTION
Hey @jalbr74,

while using your plugin, I encountered an NPE when the `target` directory does not yet exist. This can happen if someone calls `mvn clean` right before executing only your plugin. I added a fix for this situation together with some tests which show that it works and does not break other stuff when the attribution file is written. 

I hope I followed all your conventions, if not let me know and I'll fix that.

Thanks!