### PR TITLE
Add skipDownloadUrl configuration flag to speed up plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ This plugin came out of the need to get some of the same information produced by
   * Whether or not regeneration of the attribution.xml file should be forced (defaults to `false`).  Normally, if the plugin detects the timestamp of the attribution.xml file is later than the project's pom.xml file, it will not go through the process of regenerating it.  This parameter will cause it to be regenerated, regardless of file timestamps.
 * `dependencyOverrides`
   * Provides one or more `<dependencyOverride>` elements, which allow you to override values placed in the final attribution.xml file.  This feature is handy when for some reason a dependency doesn't contain certain pieces of information in its pom.  See the example below for how this is specified.
+* `skipDownloadUrl`
+  * This flag allows to skip the retrieval of the downloadUrl info (defaults to `false`). It can highly reduce the run time of the plugin if this info is not relevant as this part is quite time consuming. 
+
 
 ### Example
 

--- a/src/main/java/com/microfocus/plugins/attribution/datamodel/services/DependenciesService.java
+++ b/src/main/java/com/microfocus/plugins/attribution/datamodel/services/DependenciesService.java
@@ -10,5 +10,5 @@ import com.microfocus.plugins.attribution.datamodel.beans.DependencyOverride;
 import com.microfocus.plugins.attribution.datamodel.beans.ProjectDependency;
 
 public interface DependenciesService {
-    List<ProjectDependency> getProjectDependencies(MavenProject project, Settings settings, ArtifactRepository localRepository, DependencyOverride[] dependencyOverrides);
+    List<ProjectDependency> getProjectDependencies(MavenProject project, Settings settings, ArtifactRepository localRepository, DependencyOverride[] dependencyOverrides, boolean skipDownloadUrl);
 }

--- a/src/main/java/com/microfocus/plugins/attribution/datamodel/services/impl/DependenciesServiceImpl.java
+++ b/src/main/java/com/microfocus/plugins/attribution/datamodel/services/impl/DependenciesServiceImpl.java
@@ -54,7 +54,7 @@ public class DependenciesServiceImpl implements DependenciesService {
     private ServiceLog log = new ServiceLog();
 
     @Override
-    public List<ProjectDependency> getProjectDependencies(MavenProject project, Settings settings, ArtifactRepository localRepository, DependencyOverride[] dependencyOverrides) {
+    public List<ProjectDependency> getProjectDependencies(MavenProject project, Settings settings, ArtifactRepository localRepository, DependencyOverride[] dependencyOverrides, boolean skipDownloadUrl) {
         List<ProjectDependency> projectDependencies = new ArrayList<ProjectDependency>();
         Map<String, DependencyOverride> projectDependencyOverrides = new HashMap<String, DependencyOverride>();
 
@@ -83,17 +83,18 @@ public class DependenciesServiceImpl implements DependenciesService {
                 List<ProjectDependencyLicense> licenses = DependencyUtils.toProjectLicenses(artifactProject.getLicenses());
                 List<String> downloadUrls = new ArrayList<String>();
 
-                for (ArtifactRepository artifactRepository : artifactProject.getRemoteArtifactRepositories()) {
-                    String downloadUrl = repoUtils.getDependencyUrlFromRepository(artifact, artifactRepository);
-                    if (dependencyExistsInRepo(repoUtils, artifactRepository, artifact)) {
-                        downloadUrls.add(downloadUrl);
-                    }
-
-                    if (log.isInfoEnabled()) {
-                        System.out.print('.');
+                if ( !skipDownloadUrl) {
+                    for (ArtifactRepository artifactRepository : artifactProject.getRemoteArtifactRepositories()) {
+                        String downloadUrl = repoUtils.getDependencyUrlFromRepository(artifact, artifactRepository);
+                        if (dependencyExistsInRepo(repoUtils, artifactRepository, artifact)) {
+                            downloadUrls.add(downloadUrl);
+                        }
+    
+                        if (log.isInfoEnabled()) {
+                            System.out.print('.');
+                        }
                     }
                 }
-
                 DependencyOverride dependencyOverride = projectDependencyOverrides.get(artifact.getGroupId() + ":" + artifact.getArtifactId());
                 if (dependencyOverride != null) {
                     if (StringUtils.isNotBlank(dependencyOverride.getProjectUrl())) {

--- a/src/main/java/com/microfocus/plugins/attribution/mojos/AttributionMojo.java
+++ b/src/main/java/com/microfocus/plugins/attribution/mojos/AttributionMojo.java
@@ -41,6 +41,9 @@ public class AttributionMojo extends AbstractMojo {
     @Parameter(required = false)
     protected boolean forceRegeneration;
 
+    @Parameter(defaultValue = "false", required = false)
+    protected boolean skipDownloadUrl;
+
     // Injected services
     @Component DependenciesService dependenciesService;
     @Component ReportsService reportsService;
@@ -58,7 +61,7 @@ public class AttributionMojo extends AbstractMojo {
 
             if (outputFileOutOfDate || forceRegeneration) {
                 getLog().info("Building project dependencies list...");
-                List<ProjectDependency> projectDependencies = dependenciesService.getProjectDependencies(project, settings, localRepository, dependencyOverrides);
+                List<ProjectDependency> projectDependencies = dependenciesService.getProjectDependencies(project, settings, localRepository, dependencyOverrides, skipDownloadUrl);
 
                 getLog().info("Writing output file: " + outputFile.getAbsolutePath());
                 reportsService.createAttributionXmlFile(projectDependencies, outputFile);


### PR DESCRIPTION
The  determination of downloadUrl values from remote repositories seem to take a very long time for some of my project.  It took more than 10 minutes to run plugin in some cases, most likely due to high number of dependencies of old libs with possibly repos that no longer exist.

As the downloadUrl info is not needed for the for output I want to generate from the attribution.xml  I added  a configuration flag to skip this step.
The attribution.xml  (with empty downloadUrls tags) now gets generated in a few seconds.