### PR TITLE
Add includeTransitiveDependencies configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This plugin came out of the need to get some of the same information produced by
   * Provides one or more `<dependencyOverride>` elements, which allow you to override values placed in the final attribution.xml file.  This feature is handy when for some reason a dependency doesn't contain certain pieces of information in its pom.  See the example below for how this is specified.
 * `skipDownloadUrl`
   * This flag allows to skip the retrieval of the downloadUrl info (defaults to `false`). It can highly reduce the run time of the plugin if this info is not relevant as this part is quite time consuming. 
+* `includeTransitiveDependencies`
+  * Whether or not transitive dependencies should be included in the report (defaults to `true`). Setting it to false will include only the project dependencies. 
 
 
 ### Example

--- a/src/main/java/com/microfocus/plugins/attribution/datamodel/services/DependenciesService.java
+++ b/src/main/java/com/microfocus/plugins/attribution/datamodel/services/DependenciesService.java
@@ -10,5 +10,5 @@ import com.microfocus.plugins.attribution.datamodel.beans.DependencyOverride;
 import com.microfocus.plugins.attribution.datamodel.beans.ProjectDependency;
 
 public interface DependenciesService {
-    List<ProjectDependency> getProjectDependencies(MavenProject project, Settings settings, ArtifactRepository localRepository, DependencyOverride[] dependencyOverrides, boolean skipDownloadUrl);
+    List<ProjectDependency> getProjectDependencies(MavenProject project, Settings settings, ArtifactRepository localRepository, DependencyOverride[] dependencyOverrides, boolean skipDownloadUrl, boolean includeTransitiveDependencies);
 }

--- a/src/main/java/com/microfocus/plugins/attribution/datamodel/services/impl/DependenciesServiceImpl.java
+++ b/src/main/java/com/microfocus/plugins/attribution/datamodel/services/impl/DependenciesServiceImpl.java
@@ -54,7 +54,7 @@ public class DependenciesServiceImpl implements DependenciesService {
     private ServiceLog log = new ServiceLog();
 
     @Override
-    public List<ProjectDependency> getProjectDependencies(MavenProject project, Settings settings, ArtifactRepository localRepository, DependencyOverride[] dependencyOverrides, boolean skipDownloadUrl) {
+    public List<ProjectDependency> getProjectDependencies(MavenProject project, Settings settings, ArtifactRepository localRepository, DependencyOverride[] dependencyOverrides, boolean skipDownloadUrl, boolean includeTransitiveDependencies) {
         List<ProjectDependency> projectDependencies = new ArrayList<ProjectDependency>();
         Map<String, DependencyOverride> projectDependencyOverrides = new HashMap<String, DependencyOverride>();
 
@@ -69,7 +69,7 @@ public class DependenciesServiceImpl implements DependenciesService {
         Dependencies dependencies = new Dependencies(project, dependencyNode, classesAnalyzer);
 
         try {
-            List<Artifact> alldeps = dependencies.getAllDependencies();
+            List<Artifact> alldeps = includeTransitiveDependencies ? dependencies.getAllDependencies() : dependencies.getProjectDependencies();
 
             if (log.isInfoEnabled()) {
                 System.out.print("[INFO] Reading dependency information from available repositories.");
@@ -89,7 +89,7 @@ public class DependenciesServiceImpl implements DependenciesService {
                         if (dependencyExistsInRepo(repoUtils, artifactRepository, artifact)) {
                             downloadUrls.add(downloadUrl);
                         }
-    
+
                         if (log.isInfoEnabled()) {
                             System.out.print('.');
                         }

--- a/src/main/java/com/microfocus/plugins/attribution/mojos/AttributionMojo.java
+++ b/src/main/java/com/microfocus/plugins/attribution/mojos/AttributionMojo.java
@@ -44,6 +44,9 @@ public class AttributionMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", required = false)
     protected boolean skipDownloadUrl;
 
+    @Parameter(defaultValue = "true", required = false)
+    protected boolean includeTransitiveDependencies;
+
     // Injected services
     @Component DependenciesService dependenciesService;
     @Component ReportsService reportsService;
@@ -61,7 +64,7 @@ public class AttributionMojo extends AbstractMojo {
 
             if (outputFileOutOfDate || forceRegeneration) {
                 getLog().info("Building project dependencies list...");
-                List<ProjectDependency> projectDependencies = dependenciesService.getProjectDependencies(project, settings, localRepository, dependencyOverrides, skipDownloadUrl);
+                List<ProjectDependency> projectDependencies = dependenciesService.getProjectDependencies(project, settings, localRepository, dependencyOverrides, skipDownloadUrl, includeTransitiveDependencies);
 
                 getLog().info("Writing output file: " + outputFile.getAbsolutePath());
                 reportsService.createAttributionXmlFile(projectDependencies, outputFile);


### PR DESCRIPTION
We want to be able to get a report on just the project dependencies, excluding transitive dependencies. So I've added an includeTransitiveDependencies configuration option to allow for it. The default value of this option (true) will maintain existing functionality.